### PR TITLE
Fix paths in index file to support in-app imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-export { Button } from 'components/Button';
-export { Checkbox } from 'components/Checkbox';
-export { Icon } from 'components/Icon';

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,4 @@
+export * from './components/Button'
+export * from './components/Card'
+export * from './components/Checkbox'
+export * from './components/Icon'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "deploy-storybook": "storybook-to-ghpages",
     "test": "jest",
     "test-watch": "jest --watch",
-    "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx",
+    "build-component-index": "node ./scripts/generate-component-index"
   },
   "repository": {
     "type": "git",

--- a/scripts/generate-component-index.js
+++ b/scripts/generate-component-index.js
@@ -1,0 +1,13 @@
+const { readdirSync, writeFileSync } = require('fs');
+const { resolve } = require('path');
+
+const COMPONENT_DIRECTORY = 'components';
+
+const components = readdirSync(resolve(`${COMPONENT_DIRECTORY}`), { withFileTypes: true })
+    .filter((dir) => dir.isDirectory())
+    .map((dir) => `export * from './${COMPONENT_DIRECTORY}/${dir.name}'`);
+
+console.log(`Discovered ${components.length} component directories`, '\n');
+console.log(components.join('\n'),'\n');
+console.log('Creating index.ts file');
+writeFileSync(resolve('./index.ts'), `${components.join('\n')}\n`);


### PR DESCRIPTION
Adds a (albeit) simple script to generate top-level exports and an index.ts file for app consumption. This will only generate exports for the top level directories in `./components/` inner folders will need to have their own index.ts file structure made when created.

Run with `npm run build-component-index` it will update the index.ts file for you.