### PR TITLE
Add Input component for basic text input

### DIFF
--- a/components/Forms/Field/Field.stories.mdx
+++ b/components/Forms/Field/Field.stories.mdx
@@ -1,6 +1,7 @@
-import { Meta, Props, Story, Preview, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, ArgsTable, Story, Preview, Canvas } from '@storybook/addon-docs/blocks';
 
 import { Field } from './Field';
+import { Input } from '../Input';
 
 <Meta title="Components/Forms/Field" component={Field} />
 
@@ -12,7 +13,7 @@ The input render prop includes inner props to handle styling (className) as well
 
 ## Props
 
-<Props of={Field} />
+<ArgsTable of={Field} />
 
 ## Examples
 
@@ -26,7 +27,7 @@ The input render prop includes inner props to handle styling (className) as well
       displayValue: 'Read Only Value',
       fieldId: undefined,
       input: (inputProps) => (
-        <input type="text" {...inputProps} defaultValue="Editable Value" />
+        <Input type="text" {...inputProps} defaultValue="Editable Value" />
       ),
     }}
   >
@@ -44,7 +45,7 @@ The input render prop includes inner props to handle styling (className) as well
       displayValue: 'Read Only Value',
       isEdit: true,
       input: (inputProps) => (
-        <input type="text" {...inputProps} defaultValue="Editable Value" />
+        <Input type="text" {...inputProps} defaultValue="Editable Value" />
       ),
       fieldId: undefined,
     }}
@@ -63,7 +64,7 @@ The input render prop includes inner props to handle styling (className) as well
       displayValue: 'Read Only Value',
       isEdit: true,
       input: (inputProps) => (
-        <input type="text" {...inputProps} defaultValue="Editable Value" />
+        <Input type="text" {...inputProps} defaultValue="Editable Value" />
       ),
       helpText: 'This is help text, to help you understand the field',
       fieldId: undefined,
@@ -83,7 +84,7 @@ The input render prop includes inner props to handle styling (className) as well
       displayValue: 'Read Only Value',
       isEdit: true,
       input: (inputProps) => (
-        <input type="text" {...inputProps} defaultValue="Editable Value" />
+        <Input type="text" {...inputProps} defaultValue="Editable Value" />
       ),
       error: 'There is something invalid about this field',
       fieldId: undefined,
@@ -102,7 +103,7 @@ The input render prop includes inner props to handle styling (className) as well
       label: 'Field Label',
       displayValue: 'Read Only Value',
       input: (inputProps) => (
-        <input type="text" {...inputProps} defaultValue="Editable Value" />
+        <Input type="text" {...inputProps} defaultValue="Editable Value" />
       ),
       fieldId: undefined,
     }}
@@ -126,7 +127,7 @@ The input render prop includes inner props to handle styling (className) as well
   <Story name="Editable With Children">
     <Field label="Field Label" isEdit>
       {(inputProps) => (
-        <input type="text" {...inputProps} defaultValue="Editable Value" />
+        <Input type="text" {...inputProps} defaultValue="Editable Value" />
       )}
     </Field>
   </Story>

--- a/components/Forms/Field/Field.tsx
+++ b/components/Forms/Field/Field.tsx
@@ -4,7 +4,6 @@ import { v4 as uuidv4 } from 'uuid';
 
 export interface FieldInputProps {
   id: string;
-  className: string;
   error?: React.ReactNode;
 }
 
@@ -58,7 +57,6 @@ export const Field: FC<FieldProps> = ({
   const hasChildren = isEdit && !input && !!children;
   const inputProps: FieldInputProps = {
     id: fieldId,
-    className: 'fui-field-row__input',
     error,
   };
 

--- a/components/Forms/Field/field.css
+++ b/components/Forms/Field/field.css
@@ -20,7 +20,7 @@
       tw-duration-200
       tw-ease-out
       tw-w-full
-      tw-bg-gray-300 
+      tw-bg-gray-200 
       tw-shadow-none 
       tw-block 
       tw-rounded 
@@ -32,8 +32,16 @@
       tw-pl-3;
   }
 
-  .fui-field-row__input:hover {
-    @apply tw-bg-gray-400;
+  .fui-field-row__input:not(:focus):not(:disabled):hover {
+    @apply tw-bg-gray-300;
+  }
+
+  .fui-field-row__input:disabled {
+    @apply tw-cursor-not-allowed;
+  }
+
+  .fui-field-row__input:not(:focus):not(:disabled):hover::placeholder {
+    @apply tw-text-gray-800;
   }
 
   .fui-field-row__input:focus {

--- a/components/Forms/Input/Input.stories.mdx
+++ b/components/Forms/Input/Input.stories.mdx
@@ -1,0 +1,107 @@
+import { Meta, ArgsTable, Story, Preview, Canvas } from '@storybook/addon-docs/blocks';
+
+import { Input } from './Input';
+import { Field } from '../Field';
+
+<Meta title="Components/Forms/Input" component={Input} />
+
+# Input
+
+A basic form element, accepts any standard type, passes through any additional valid html props.
+
+## Props (any valid HTML Prop)
+
+<ArgsTable of={Input} />
+
+## Examples
+
+### Basic `Input`
+
+<Canvas>
+  <Story
+    name="Basic"
+    args={{
+      id: undefined,
+    }}
+  >
+    {(args) => <Input {...args} />}
+  </Story>
+</Canvas>
+
+### Usage with `Field`
+
+<Canvas>
+  <Story name="Field">
+    <Field fieldId="text-field" label="Text Field" isEdit>
+      {(innerProps) => <Input {...innerProps} placeholder="I'm a text field!" />}
+    </Field>
+  </Story>
+</Canvas>
+
+### Placeholder Input
+
+<Canvas>
+  <Story
+    name="Placeholder"
+    args={{
+      id: undefined,
+      placeholder: 'Enter some text...',
+    }}
+  >
+    {(args) => <Input {...args} />}
+  </Story>
+</Canvas>
+
+### Disabled Input
+
+<Canvas>
+  <Story
+    name="Disabled"
+    args={{
+      id: undefined,
+      placeholder: 'This input is disabled',
+      disabled: true,
+    }}
+  >
+    {(args) => <Input {...args} />}
+  </Story>
+</Canvas>
+
+### Input with value
+
+<Canvas>
+  <Story
+    name="Value"
+    args={{
+      id: undefined,
+      placeholder: 'Enter some text',
+      defaultValue: 'I have a value!',
+    }}
+  >
+    {(args) => <Input {...args} />}
+  </Story>
+</Canvas>
+
+### Extra Input types
+
+<Canvas>
+  <Story
+    name="Types"
+    args={{
+      types: ['password', 'number', 'email', 'hidden', 'search', 'tel'],
+    }}
+  >
+    {(args) =>
+      args.types.map((type) => (
+        <div key={type} className="tw-mt-2 tw-mb-2">
+          <Input
+            id={`${type}-input`}
+            type={type}
+            key={type}
+            placeholder={`${type} Input`}
+          />
+        </div>
+      ))
+    }
+  </Story>
+</Canvas>

--- a/components/Forms/Input/Input.test.tsx
+++ b/components/Forms/Input/Input.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import fireEvent from '@testing-library/user-event';
+
+import { Input } from './Input';
+
+describe('Component Input', () => {
+  test('should render an input defaulted to text', () => {
+    const { container } = render(<Input id="test" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should pass through any supported html input props', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { container } = render(
+      <Input
+        name="test"
+        id="test"
+        type="text"
+        disabled={true}
+        aria-label="test"
+        data-test="test"
+        ref={ref}
+      />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+    expect(ref.current?.getAttribute('id')).toBe('test');
+  });
+
+  test('should call onChange callbacks', () => {
+    const handleChange = jest.fn();
+    const { getByTestId } = render(
+      <Input id="test" data-testid="test" onChange={handleChange} />
+    );
+    fireEvent.type(getByTestId('test'), 'test');
+    expect(handleChange).toHaveBeenCalled();
+  });
+});

--- a/components/Forms/Input/Input.tsx
+++ b/components/Forms/Input/Input.tsx
@@ -1,0 +1,21 @@
+import React, { forwardRef, ForwardRefRenderFunction } from 'react';
+import cx from 'classnames';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  type?: 'text' | 'password' | 'number' | 'email' | 'hidden' | 'search' | 'tel';
+}
+
+const ForwardInput: ForwardRefRenderFunction<HTMLInputElement, InputProps> = (
+  { type = 'text', id = `field_${uuidv4()}`, className, ...restProps }: InputProps,
+  ref: React.MutableRefObject<HTMLInputElement>
+): React.ReactElement => {
+  const classNames = cx('fui-field-row__input', className);
+  return (
+    <>
+      <input ref={ref} className={classNames} id={id} type={type} {...restProps} />
+    </>
+  );
+};
+
+export const Input = forwardRef(ForwardInput);

--- a/components/Forms/Input/__snapshots__/Input.test.tsx.snap
+++ b/components/Forms/Input/__snapshots__/Input.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Input should pass through any supported html input props 1`] = `
+<input
+  aria-label="test"
+  class="fui-field-row__input"
+  data-test="test"
+  disabled=""
+  id="test"
+  name="test"
+  type="text"
+/>
+`;
+
+exports[`Component Input should render an input defaulted to text 1`] = `
+<input
+  class="fui-field-row__input"
+  id="test"
+  type="text"
+/>
+`;

--- a/components/Forms/Input/index.ts
+++ b/components/Forms/Input/index.ts
@@ -1,0 +1,1 @@
+export * from './Input';


### PR DESCRIPTION
- Adds `<Input />` which wraps and classes a basic input
  - Allows for ref forwarding to prepare for react-hook-form interactions
  - Allows any standard html input props to be passed through (including callbacks)
  - Limits input types
- Adds Tests
- Updates Field examples to use `<Input />`

Resolves #9 

Preview: https://deploy-preview-18--laughing-shockley-2b3f4c.netlify.app/?path=/docs/components-forms-input--basic