### PR TITLE
Add SchemaForm for JSON generated react-hook-form forms

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,7 @@
     "react/prop-types": "off", // Replaced by TypeScript
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error",
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }],
     // Relaxed TypeScript rules
     "@typescript-eslint/no-empty-interface": [
       "error",

--- a/components/Forms/Field/Field.tsx
+++ b/components/Forms/Field/Field.tsx
@@ -61,7 +61,7 @@ export const Field: FC<FieldProps> = ({
   };
 
   return (
-    <div className={classNames}>
+    <div className={classNames} data-testid={fieldId}>
       <div className="fui-field-row__label">
         <label htmlFor={fieldId}>{label}</label>
       </div>

--- a/components/Forms/SchemaForm/SchemaForm.stories.mdx
+++ b/components/Forms/SchemaForm/SchemaForm.stories.mdx
@@ -1,0 +1,289 @@
+import { useCallback } from 'react';
+import {
+  Meta,
+  ArgsTable,
+  Story,
+  Preview,
+  Canvas,
+  Source,
+} from '@storybook/addon-docs/blocks';
+
+import { useForm } from 'react-hook-form';
+
+import { Button } from '../../Button';
+
+import { SchemaForm } from './SchemaForm';
+import { useErrorMessages } from './hooks';
+
+import {
+  basicSchema,
+  dependsSchema,
+  validationSchema,
+  realWorldSchema,
+  externalConditionalSchema,
+  decorators,
+  ExampleWrapper,
+} from './schema-form-data';
+
+<Meta
+  title="Components/Forms/SchemaForm"
+  component={SchemaForm}
+  decorators={decorators}
+  parameters={{ docs: { source: { type: 'code' } } }}
+/>
+
+# SchemaForm
+
+A SchemaForm is a form generator for basic forms, described by JSON. Given a JSON configuration describing
+form fields metadata and values, `SchemaForm` will construct a `react-hook-form` based form with onSubmit handling, conditional fields, and validation.
+
+### Schemas are simple JSON structures
+
+A form schema consists of two fields, an object of Fields and an optional field order array, which will provide context to the generator about the UI order of the fields.
+
+<Source
+  code={`export interface FormSchema {
+  fields: Record<string, SchemaField>;
+  field_order: string[];
+}`}
+/>
+
+Fields consist of metadata and a value, metadata is the provided configuration for the field.
+
+<Source
+  code={`export interface SchemaField {
+  metadata: {
+    field_type: 'text' | 'number' | 'select';
+    label: string;
+    description: string;
+    encrypt?: boolean;
+    validation: SchemaValidation;
+    depends_on: Record<string, string | number>;
+  };
+  value: string | number;
+}`}
+/>
+
+### Example FormSchema
+
+<Source
+  code={`export const basicSchema: FormSchema = {
+  fields: {
+    one: {
+      metadata: {
+        label: 'First Field',
+        field_type: 'text',
+        description: 'This is the first field',
+        validation: {},
+        depends_on: {},
+      },
+      value: 1,
+    },
+    two: {
+      metadata: {
+        label: 'Third Field',
+        field_type: 'text',
+        description: 'This is the third field',
+        validation: {},
+        depends_on: {},
+      },
+      value: 2,
+    },
+    three: {
+      metadata: {
+        label: 'Second Field',
+        field_type: 'text',
+        description: 'This is the second field',
+        validation: {},
+        depends_on: {},
+      },
+      value: 3,
+    },
+    four: {
+      metadata: {
+        label: 'Select Field',
+        field_type: 'select',
+        options: [
+          { label: 'Value 1', value: 1 },
+          { label: 'Value 2', value: 2 },
+        ],
+        description: 'This is a select field',
+        validation: {},
+        depends_on: {},
+      },
+      value: 3,
+    },
+  },
+  field_order: ['one', 'three', 'two', 'four'],
+};
+`}
+/>
+
+## Props
+
+<ArgsTable of={SchemaForm} />
+
+## Examples
+
+#### Examples Note
+
+These code examples use a storybook decorator to provide a wrapper for a form/button/calling out to react-hook-form for methods. A
+proper implementation of `<FormSchema />` would be wrapped in a react-hook-form driven component. The ExampleWrapper provides the methods back to `FormSchema` as a react children callback
+but this isn't necessary in normal implementations.
+
+Our examples also use external schema's and storybook does not load those directly they can be found here: [Example Schemas](https://github.com/fishtown-analytics/fishtown-ui/tree/master/components/Forms/SchemaForm/schema-form-data.tsx)
+
+#### ExampleWrapper
+
+<Source
+  code={`export const ExampleWrapper = ({ isEdit, children }) => {
+  const { handleSubmit, getValues, errors, register, formState, control } = useForm();
+  return (
+    <form>
+      {children({ errors, register, getValues, control, isEdit, formState })}
+      {isEdit && (
+        <Button onClick={handleSubmit((values) => console.log(values))}>
+          Validate
+        </Button>
+      )}
+    </form>
+  );
+};`}
+/>
+
+### Basic read-only `SchemaForm`
+
+<Canvas>
+  <Story
+    name="Basic"
+    args={{
+      isEdit: false,
+    }}
+  >
+    {({ register, getValues, errors, formState, isEdit, control }) => {
+      return (
+        <SchemaForm
+          schema={basicSchema}
+          isEdit={isEdit}
+          register={register}
+          getValues={getValues}
+          errors={useErrorMessages(errors, formState)}
+          control={control}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Basic edit mode `SchemaForm`
+
+<Canvas>
+  <Story
+    name="Editable"
+    args={{
+      isEdit: true,
+    }}
+  >
+    {({ register, getValues, errors, formState, isEdit, control }) => {
+      return (
+        <SchemaForm
+          schema={basicSchema}
+          isEdit={isEdit}
+          register={register}
+          getValues={getValues}
+          errors={useErrorMessages(errors, formState)}
+          control={control}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
+### `SchemaForm` with validation
+
+The `useErrorMessages` custom hook provides error message memoization, handling, and a hook for customizing error messages.
+
+<Canvas>
+  <Story name="Validation" args={{ isEdit: true }}>
+    {({ register, getValues, errors, formState, isEdit, control }) => {
+      return (
+        <SchemaForm
+          schema={validationSchema}
+          isEdit={isEdit}
+          register={register}
+          getValues={getValues}
+          errors={useErrorMessages(errors, formState)}
+          control={control}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
+### `SchemaForm` with conditional fields
+
+`depends_on` metadata on fields provides a way to conditionally show/hide fields on the fly.
+
+<Canvas>
+  <Story name="Conditional" args={{ isEdit: true }}>
+    {({ register, getValues, errors, formState, isEdit, control }) => {
+      return (
+        <SchemaForm
+          schema={dependsSchema}
+          isEdit={isEdit}
+          register={register}
+          getValues={getValues}
+          errors={useErrorMessages(errors, formState)}
+          control={control}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
+### `SchemaForm` with non-field based conditions
+
+`getValues` can be decorated with additional properties to allow conditional fields to be based on external factors
+
+<Canvas>
+  <Story name="External Conditionals" args={{ isEdit: true, showMore: false }}>
+    {({ register, getValues, errors, formState, control, isEdit, extraArgs }) => {
+      const provideValues = useCallback(
+        () => ({
+          ...getValues(),
+          ...extraArgs,
+        }),
+        [getValues, extraArgs]
+      );
+      return (
+        <SchemaForm
+          schema={externalConditionalSchema}
+          isEdit={isEdit}
+          register={register}
+          getValues={provideValues}
+          errors={useErrorMessages(errors, formState)}
+          control={control}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
+### "Real World" Example
+
+<Canvas>
+  <Story name="Real World" args={{ isEdit: true }}>
+    {({ register, getValues, errors, isEdit, formState, control }) => {
+      return (
+        <SchemaForm
+          schema={realWorldSchema}
+          isEdit={isEdit}
+          register={register}
+          getValues={getValues}
+          errors={useErrorMessages(errors, formState)}
+          control={control}
+        />
+      );
+    }}
+  </Story>
+</Canvas>

--- a/components/Forms/SchemaForm/SchemaForm.test.tsx
+++ b/components/Forms/SchemaForm/SchemaForm.test.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+
+import { SchemaForm } from './SchemaForm';
+import { FormSchema } from './types';
+import { useErrorMessages } from './hooks';
+
+const Harness: React.FC<{
+  Form: typeof SchemaForm;
+  schema: FormSchema;
+  isEdit?: boolean;
+  triggerSubmit?: boolean;
+  valueOverride?: Record<string, any>;
+  errorOverride?: Record<string, string | { submitCount: number; errorCount: number }>;
+  onSubmit?(): void;
+}> = ({
+  Form,
+  schema,
+  errorOverride,
+  valueOverride,
+  isEdit = false,
+  triggerSubmit = false,
+  onSubmit = jest.fn(),
+}) => {
+  const { control, formState, errors, register, handleSubmit, getValues } = useForm();
+  if (triggerSubmit) {
+    handleSubmit(onSubmit);
+  }
+  const errorMessages = useErrorMessages(errors, formState);
+  const provideValues = valueOverride
+    ? () => ({ ...getValues(), ...valueOverride })
+    : getValues;
+  return (
+    <form>
+      <Form
+        isEdit={isEdit}
+        getValues={provideValues}
+        control={control}
+        errors={errorOverride || errorMessages}
+        schema={schema}
+        register={register}
+      />
+    </form>
+  );
+};
+let testSchema: FormSchema = { fields: {}, field_order: [] };
+
+describe('Component SchemaForm', () => {
+  beforeEach(() => {
+    testSchema = {
+      fields: {
+        test1: {
+          metadata: {
+            id: 'test1',
+            label: 'Test 1',
+            field_type: 'text',
+            description: 'Test Description 1',
+            validation: {},
+            depends_on: {},
+          },
+          value: 'test one',
+        },
+        test2: {
+          metadata: {
+            id: 'test2',
+            label: 'Test 2',
+            field_type: 'text',
+            description: 'Test Description 2',
+            validation: {
+              required: false,
+            },
+            depends_on: {
+              test1: 'test one',
+            },
+          },
+          value: 'test two',
+        },
+        testnotrendered: {
+          metadata: {
+            id: 'testnotrendered',
+            label: 'Test 2',
+            field_type: 'text',
+            description: 'Test Description 2',
+            validation: {
+              required: false,
+            },
+            depends_on: {
+              test1: 'test one',
+            },
+          },
+          value: 'test not rendered',
+        },
+        testhidden: {
+          metadata: {
+            id: 'testhidden',
+            label: 'Test hidden',
+            field_type: 'hidden',
+            description: 'Test Description Hidden',
+            validation: {
+              required: false,
+            },
+          },
+          value: 'test hidden',
+        },
+        testselect: {
+          metadata: {
+            id: 'testselect',
+            label: 'Test Select',
+            field_type: 'select',
+            options: [
+              { label: 'Option 1', value: '1' },
+              { label: 'Option 2', value: '2' },
+            ],
+            description: 'Test Description Select',
+            validation: {
+              required: false,
+            },
+          },
+          value: '1',
+        },
+      },
+      field_order: ['test1', 'test2', 'testhidden', 'testselect'],
+    };
+  });
+  test('should render form fields based on a schema in view mode', () => {
+    const { container } = render(<Harness schema={testSchema} Form={SchemaForm} />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+  test('should render form fields based on a schema in edit mode', () => {
+    const { testselect, ...fields } = testSchema.fields;
+    const baseSchema = {
+      fields: fields,
+      field_order: testSchema.field_order.slice(0, 3),
+    };
+    const { container } = render(
+      <Harness schema={baseSchema} Form={SchemaForm} isEdit />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should show error messages if fields are invalid', () => {
+    const errorSchema: FormSchema = { ...testSchema };
+    // @ts-ignore - we know this is there
+    errorSchema.fields.test1.metadata.validation.required = true;
+    errorSchema.fields.test1.value = '';
+    const { getByText } = render(
+      <Harness
+        schema={errorSchema}
+        Form={SchemaForm}
+        isEdit
+        errorOverride={{ test1: 'ERROR' }}
+      />
+    );
+
+    expect(getByText('ERROR')).toBeInTheDocument();
+  });
+
+  test('should show a conditional field when a condition is met', () => {
+    const { getByTestId } = render(
+      <Harness schema={testSchema} Form={SchemaForm} isEdit />
+    );
+    expect(getByTestId('test2').getAttribute('class')?.includes('tw-hidden')).toBe(
+      false
+    );
+  });
+
+  test('should hide a conditional field when a condition is not met', () => {
+    const noShowSchema = { ...testSchema };
+    noShowSchema.fields.test1.value = '';
+    const { getByTestId } = render(
+      <Harness schema={noShowSchema} Form={SchemaForm} isEdit />
+    );
+    expect(getByTestId('test2').getAttribute('class')?.includes('tw-hidden')).toBe(
+      true
+    );
+  });
+
+  test('should show conditional fields based on external factors', () => {
+    const externalSchema = { ...testSchema };
+    externalSchema.fields.test2.metadata.depends_on = {
+      someValue: true,
+    };
+
+    const { getByTestId } = render(
+      <Harness
+        schema={externalSchema}
+        Form={SchemaForm}
+        isEdit
+        valueOverride={{ someValue: true }}
+      />
+    );
+    expect(getByTestId('test2').getAttribute('class')?.includes('tw-hidden')).toBe(
+      false
+    );
+  });
+});

--- a/components/Forms/SchemaForm/SchemaForm.tsx
+++ b/components/Forms/SchemaForm/SchemaForm.tsx
@@ -1,0 +1,201 @@
+import React, { FC, useMemo } from 'react';
+import {
+  Controller,
+  Control,
+  UseFormMethods,
+  ValidationRules,
+  useWatch,
+} from 'react-hook-form';
+
+import { Field } from '../Field';
+import { Input } from '../Input';
+import { Select, SelectOption } from '../Select';
+
+import { FormSchema } from './types';
+import { validationRules } from './helpers';
+
+export interface SchemaFormProps {
+  schema: FormSchema;
+  control: Control;
+  isEdit?: boolean;
+  errors?: Record<string, string | { submitCount: number; errorCount: number }>;
+  register: UseFormMethods['register'];
+  getValues?: UseFormMethods['getValues'];
+}
+
+export const SchemaForm: FC<SchemaFormProps> = ({
+  schema,
+  isEdit = false,
+  register,
+  control,
+  errors = {},
+  getValues = () => ({}),
+}): React.ReactElement => {
+  const fieldOrder = useMemo(() => schema.field_order || Object.keys(schema.fields), [
+    schema.field_order,
+    schema.fields,
+  ]);
+  // The hook values (from react-hook-form) only populate after the first submit
+  // We'll mix them together with the default values (prefer the react-hook-form values)
+  const hookValues = getValues();
+  const knownValues = useMemo(() => {
+    if (Object.keys(hookValues).length === 0) {
+      return fieldOrder.reduce((fieldValues, fieldKey) => {
+        const field = schema.fields[fieldKey];
+        if (field) {
+          fieldValues[fieldKey] =
+            field.metadata.field_type === 'select'
+              ? String((field.value as Record<string, any>).value)
+              : String(field.value);
+        }
+        return fieldValues;
+      }, {});
+    } else {
+      return hookValues;
+    }
+  }, [fieldOrder, hookValues, schema.fields]);
+
+  // Calculate which fields have fields that depend on them
+  const dependedOn = Object.keys(
+    fieldOrder.reduce((allDepends: Record<string, string>, fieldKey: string) => {
+      const field = schema.fields[fieldKey];
+      if (field) {
+        const innerDepends = Object.keys(field.metadata?.depends_on ?? {}).reduce(
+          (depends, depend) => {
+            depends[depend] = 1;
+            return depends;
+          },
+          {}
+        );
+        return { ...allDepends, ...innerDepends };
+      }
+      return allDepends;
+    }, {})
+  );
+
+  // Create react-hook-form watchers to re-render when values change
+  const watchedValues = useWatch({
+    control,
+    name: dependedOn,
+    defaultValue: dependedOn.reduce((defaultValues, fieldKey) => {
+      const field = schema.fields[fieldKey];
+      if (field) {
+        defaultValues[fieldKey] = String(field.value);
+      }
+      return defaultValues;
+    }, {}),
+  });
+
+  // Mix together any watched values with provided getValues values and extra info we might care about
+  const currentValues = {
+    ...knownValues,
+    ...watchedValues,
+  };
+
+  // Create our array of fields to render
+  const fields = fieldOrder.map((fieldKey) => {
+    const field = schema.fields[fieldKey];
+    if (field) {
+      const validation: ValidationRules = field.metadata.validation
+        ? validationRules(field.metadata.validation, field)
+        : {};
+
+      const dependencyMap = field.metadata?.depends_on ?? {};
+      const dependencies = Object.keys(dependencyMap);
+
+      let shouldShowField = true;
+
+      if (dependencies) {
+        shouldShowField = dependencies.every((dependency) => {
+          const isDependencySelect = currentValues[dependency].value !== undefined;
+          const value = isDependencySelect
+            ? currentValues[dependency].value
+            : currentValues[dependency];
+          return (
+            value === dependencyMap[dependency] ||
+            value === String(dependencyMap[dependency])
+          );
+        });
+      }
+      // Avoid passing non-standard html props into a field
+      const { encrypt, ...fieldMeta } = field.metadata;
+      if (field.metadata.field_type === 'hidden') {
+        return (
+          <Input
+            key={fieldKey}
+            id={fieldMeta.id}
+            type={field.metadata.field_type}
+            defaultValue={String(field.value || '')}
+            name={fieldKey}
+            ref={register(validation)}
+            {...fieldMeta}
+          />
+        );
+      } else if (field.metadata.field_type === 'select') {
+        const selectedOption: SelectOption | undefined = field.metadata.options?.find(
+          (option) => option.value === field.value
+        );
+        return (
+          <Field
+            className={!shouldShowField ? 'tw-hidden' : ''}
+            key={fieldKey}
+            label={field.metadata.label}
+            isEdit={isEdit}
+            displayValue={selectedOption?.label ?? (field.value || '')}
+            error={errors[fieldKey]}
+            helpText={field.metadata.description}
+            fieldId={field.metadata.id}
+          >
+            {(fieldProps) => (
+              <Controller
+                control={control}
+                name={fieldKey}
+                defaultValue={field.value}
+                render={({ onChange }) => (
+                  <Select
+                    {...fieldProps}
+                    onChange={onChange}
+                    options={field.metadata.options}
+                    value={selectedOption}
+                    error={errors[fieldKey] ? String(errors[fieldKey]) : undefined}
+                  />
+                )}
+              />
+            )}
+          </Field>
+        );
+      } else {
+        // If all else fails, use an Input
+        return (
+          <Field
+            className={!shouldShowField ? 'tw-hidden' : ''}
+            key={fieldKey}
+            fieldId={field.metadata.id}
+            label={field.metadata.label}
+            isEdit={isEdit}
+            displayValue={field.value || ''}
+            error={errors[fieldKey]}
+            helpText={field.metadata.description}
+          >
+            {(innerProps) => (
+              <Input
+                {...innerProps}
+                type={
+                  field.metadata.field_type !== 'select'
+                    ? field.metadata.field_type
+                    : 'hidden'
+                }
+                defaultValue={String(field.value || '')}
+                name={fieldKey}
+                ref={register(validation)}
+                {...fieldMeta}
+              />
+            )}
+          </Field>
+        );
+      }
+    }
+  });
+
+  return <>{fields}</>;
+};

--- a/components/Forms/SchemaForm/__snapshots__/SchemaForm.test.tsx.snap
+++ b/components/Forms/SchemaForm/__snapshots__/SchemaForm.test.tsx.snap
@@ -1,0 +1,160 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component SchemaForm should render form fields based on a schema in edit mode 1`] = `
+<form>
+  <div
+    class="fui-field-row tw-flex tw-flex-row tw-pt-2 tw-pb-2 fui-field-row--is-edit"
+    data-testid="test1"
+  >
+    <div
+      class="fui-field-row__label"
+    >
+      <label
+        for="test1"
+      >
+        Test 1
+      </label>
+    </div>
+    <div
+      class="fui-field-row__value"
+    >
+      <input
+        class="fui-field-row__input"
+        depends_on="[object Object]"
+        description="Test Description 1"
+        field_type="text"
+        id="test1"
+        label="Test 1"
+        name="test1"
+        type="text"
+        validation="[object Object]"
+        value="test one"
+      />
+      <p
+        class="tw-text-xs tw-text-gray-600 tw-italic tw-mt-1 tw-mb-1"
+      >
+        Test Description 1
+      </p>
+    </div>
+  </div>
+  <div
+    class="fui-field-row tw-flex tw-flex-row tw-pt-2 tw-pb-2 fui-field-row--is-edit"
+    data-testid="test2"
+  >
+    <div
+      class="fui-field-row__label"
+    >
+      <label
+        for="test2"
+      >
+        Test 2
+      </label>
+    </div>
+    <div
+      class="fui-field-row__value"
+    >
+      <input
+        class="fui-field-row__input"
+        depends_on="[object Object]"
+        description="Test Description 2"
+        field_type="text"
+        id="test2"
+        label="Test 2"
+        name="test2"
+        type="text"
+        validation="[object Object]"
+        value="test two"
+      />
+      <p
+        class="tw-text-xs tw-text-gray-600 tw-italic tw-mt-1 tw-mb-1"
+      >
+        Test Description 2
+      </p>
+    </div>
+  </div>
+  <input
+    class="fui-field-row__input"
+    description="Test Description Hidden"
+    field_type="hidden"
+    id="testhidden"
+    label="Test hidden"
+    name="testhidden"
+    type="hidden"
+    validation="[object Object]"
+    value="test hidden"
+  />
+</form>
+`;
+
+exports[`Component SchemaForm should render form fields based on a schema in view mode 1`] = `
+<form>
+  <div
+    class="fui-field-row tw-flex tw-flex-row tw-pt-2 tw-pb-2 fui-field-row--is-view"
+    data-testid="test1"
+  >
+    <div
+      class="fui-field-row__label"
+    >
+      <label
+        for="test1"
+      >
+        Test 1
+      </label>
+    </div>
+    <div
+      class="fui-field-row__value"
+    >
+      test one
+    </div>
+  </div>
+  <div
+    class="fui-field-row tw-flex tw-flex-row tw-pt-2 tw-pb-2 fui-field-row--is-view"
+    data-testid="test2"
+  >
+    <div
+      class="fui-field-row__label"
+    >
+      <label
+        for="test2"
+      >
+        Test 2
+      </label>
+    </div>
+    <div
+      class="fui-field-row__value"
+    >
+      test two
+    </div>
+  </div>
+  <input
+    class="fui-field-row__input"
+    description="Test Description Hidden"
+    field_type="hidden"
+    id="testhidden"
+    label="Test hidden"
+    name="testhidden"
+    type="hidden"
+    validation="[object Object]"
+    value="test hidden"
+  />
+  <div
+    class="fui-field-row tw-flex tw-flex-row tw-pt-2 tw-pb-2 fui-field-row--is-view"
+    data-testid="testselect"
+  >
+    <div
+      class="fui-field-row__label"
+    >
+      <label
+        for="testselect"
+      >
+        Test Select
+      </label>
+    </div>
+    <div
+      class="fui-field-row__value"
+    >
+      Option 1
+    </div>
+  </div>
+</form>
+`;

--- a/components/Forms/SchemaForm/helpers/index.ts
+++ b/components/Forms/SchemaForm/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './validation';

--- a/components/Forms/SchemaForm/helpers/validation.ts
+++ b/components/Forms/SchemaForm/helpers/validation.ts
@@ -1,0 +1,81 @@
+import { ValidationRules } from 'react-hook-form';
+
+import { SchemaField, SchemaValidation } from '../types';
+
+export type ValidationValue = string | number | boolean | RegExp;
+export type Validator = (
+  value: ValidationValue,
+  field: SchemaField
+) => Record<string, ValidationValue>;
+
+const patternValidators: Record<string, Record<string, string | RegExp>> = {
+  email: {
+    value: /^\S+@\S+$/i,
+    message: 'must be a valid email address',
+  },
+  hostname: {
+    value: /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/i,
+    message: 'must be a valid host name',
+  },
+  fqdn: {
+    value: /[-a-zA-Z0-9@:%_+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_+.~#?&//=]*)?/i,
+    message: 'must be a valid url',
+  },
+};
+
+const validators: Record<string, Validator> = {
+  required: (value, field) => ({
+    required: value ? `${field.metadata.label} is required.` : false,
+  }),
+  min: (value, field) => ({
+    value,
+    message: `${field.metadata.label} must be greater than ${value}.`,
+  }),
+  max: (value, field) => ({
+    value,
+    message: `${field.metadata.label} must be less than ${value}.`,
+  }),
+  minLength: (value, field) => ({
+    value,
+    message: `${field.metadata.label} must be shorter than ${value} characters.`,
+  }),
+  maxLength: (value, field) => ({
+    value,
+    message: `${field.metadata.label} must be longer than ${value} characters.`,
+  }),
+
+  pattern: (value, field) => {
+    const { value: regexValue, message } = patternValidators[String(value)];
+    return {
+      value: regexValue,
+      message: `${field.metadata.label} ${message}`,
+    };
+  },
+};
+
+export const validationRules = (
+  validation: SchemaValidation,
+  field: SchemaField
+): ValidationRules => {
+  const validationTypes = Object.keys(validation);
+
+  const rules = validationTypes.reduce(
+    (validationRules: ValidationRules, validationKey: string) => {
+      if (validators[validationKey]) {
+        const rule = validators[validationKey](validation[validationKey], field);
+        const normalizedKey = patternValidators[validationKey]
+          ? 'pattern'
+          : validationKey;
+
+        validationRules = {
+          ...validationRules,
+          [normalizedKey]: rule.required ? rule.required : rule,
+        };
+      }
+      return validationRules;
+    },
+    {}
+  );
+
+  return rules;
+};

--- a/components/Forms/SchemaForm/hooks/index.ts
+++ b/components/Forms/SchemaForm/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useErrorMessages';

--- a/components/Forms/SchemaForm/hooks/useErrorMessages.ts
+++ b/components/Forms/SchemaForm/hooks/useErrorMessages.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { FieldError, FormState } from 'react-hook-form';
+
+// Memoized and normalized error messages
+export const useErrorMessages = (
+  errors: Record<string, FieldError>,
+  formState: FormState<any>
+): Record<string, string | { submitCount: number; errorCount: number }> => {
+  const keyCount = Object.keys(errors).length;
+  return useMemo(() => {
+    const messages = {
+      _meta: {
+        submitCount: formState.submitCount,
+        errorCount: keyCount,
+      },
+    };
+    return Object.keys(errors).reduce((messages, key) => {
+      messages[key] = errors[key].message;
+      return messages;
+    }, messages);
+  }, [errors, formState.submitCount, keyCount]);
+};

--- a/components/Forms/SchemaForm/index.ts
+++ b/components/Forms/SchemaForm/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './hooks';
+export * from './SchemaForm';

--- a/components/Forms/SchemaForm/schema-form-data.tsx
+++ b/components/Forms/SchemaForm/schema-form-data.tsx
@@ -1,0 +1,426 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+
+import { Button } from '../../Button';
+
+import { FormSchema } from './types';
+
+export const ExampleWrapper = ({ isEdit, children }) => {
+  const { handleSubmit, getValues, errors, register, formState, control } = useForm();
+  return (
+    <form>
+      {children({ errors, register, getValues, control, isEdit, formState })}
+      {isEdit && (
+        <Button onClick={handleSubmit((values) => console.log(values))}>
+          Validate
+        </Button>
+      )}
+    </form>
+  );
+};
+export const decorators = [
+  (Story, { args }) => (
+    <ExampleWrapper isEdit={args.isEdit}>
+      {(innerProps) => Story({ args: { ...innerProps, extraArgs: args } })}
+    </ExampleWrapper>
+  ),
+];
+
+export const basicSchema: FormSchema = {
+  fields: {
+    one: {
+      metadata: {
+        label: 'First Field',
+        field_type: 'text',
+        description: 'This is the first field',
+        validation: {},
+        depends_on: {},
+      },
+      value: 1,
+    },
+    two: {
+      metadata: {
+        label: 'Third Field',
+        field_type: 'text',
+        description: 'This is the third field',
+        validation: {},
+        depends_on: {},
+      },
+      value: 2,
+    },
+    three: {
+      metadata: {
+        label: 'Second Field',
+        field_type: 'text',
+        description: 'This is the second field',
+        validation: {},
+        depends_on: {},
+      },
+      value: 3,
+    },
+    four: {
+      metadata: {
+        label: 'Select Field',
+        field_type: 'select',
+        options: [
+          { label: 'Value 1', value: '1' },
+          { label: 'Value 2', value: '2' },
+        ],
+        description: 'This is a select field',
+        validation: {},
+        depends_on: {},
+      },
+      value: '2',
+    },
+  },
+  field_order: ['one', 'three', 'two', 'four'],
+};
+
+export const validationSchema: FormSchema = {
+  fields: {
+    required: {
+      metadata: {
+        label: 'Required',
+        field_type: 'text',
+        description: 'This field is required!',
+        validation: {
+          required: true,
+        },
+        depends_on: {},
+      },
+      value: '',
+    },
+    min: {
+      metadata: {
+        label: 'Minimum',
+        field_type: 'number',
+        description: 'This field has a minimum required value of 3',
+        validation: {
+          min: 3,
+        },
+        depends_on: {},
+      },
+      value: 1,
+    },
+    max: {
+      metadata: {
+        label: 'Maximum',
+        field_type: 'number',
+        description: 'This field has a maximum required value of 5',
+        validation: {
+          max: 5,
+        },
+        depends_on: {},
+      },
+      value: 7,
+    },
+    minLength: {
+      metadata: {
+        label: 'Min Length',
+        field_type: 'text',
+        description: 'This field has a minimum required length of 10',
+        validation: {
+          minLength: 10,
+        },
+        depends_on: {},
+      },
+      value: 'too short',
+    },
+    maxLength: {
+      metadata: {
+        label: 'Max Length',
+        field_type: 'text',
+        description: 'This field has a maximum required length of 5',
+        validation: {
+          maxLength: 5,
+        },
+        depends_on: {},
+      },
+      value: 'too long',
+    },
+    email: {
+      metadata: {
+        label: 'Email',
+        field_type: 'text',
+        description: 'This field must be a valid email address',
+        validation: {
+          pattern: 'email',
+        },
+        depends_on: {},
+      },
+      value: 'not an email',
+    },
+    hostname: {
+      metadata: {
+        label: 'Host Name',
+        field_type: 'text',
+        description: 'This field must be a valid hostname',
+        validation: {
+          pattern: 'hostname',
+        },
+        depends_on: {},
+      },
+      value: 'not a hostname',
+    },
+    url: {
+      metadata: {
+        label: 'URL',
+        field_type: 'text',
+        description: 'This field must be a valid url',
+        validation: {
+          required: true,
+          pattern: 'fqdn',
+        },
+        depends_on: {},
+      },
+      value: 'not a url',
+    },
+  },
+  field_order: [
+    'required',
+    'min',
+    'max',
+    'minLength',
+    'maxLength',
+    'email',
+    'hostname',
+    'url',
+  ],
+};
+
+export const dependsSchema: FormSchema = {
+  fields: {
+    unconditional: {
+      metadata: {
+        label: 'Unconditional Field',
+        field_type: 'text',
+        description: 'This is the first field',
+        validation: {},
+        depends_on: {},
+      },
+      value: `I don't depend on anything!`,
+    },
+    conditional_trigger: {
+      metadata: {
+        label: 'Select Field',
+        field_type: 'select',
+        options: [
+          { label: 'Condition 1', value: '1' },
+          { label: 'Condition 2', value: '2' },
+        ],
+        description: 'This field determines the rest of the form',
+        validation: {
+          required: true,
+        },
+        depends_on: {},
+      },
+      value: '1',
+    },
+    conditional_sub: {
+      metadata: {
+        label: 'Sub-Conditional Field',
+        field_type: 'text',
+        description: 'This is conditional on both selects',
+        validation: {},
+        depends_on: {
+          conditional_trigger: 1,
+          conditional_1: 'show',
+        },
+      },
+      value: 'Extra Conditional!',
+    },
+    conditional_1: {
+      metadata: {
+        label: 'Conditional Field 1',
+        field_type: 'select',
+        description:
+          'This is conditional on the select, it also determines the display of a sub-conditional',
+        options: [
+          { label: "Don't Show more", value: 'noshow' },
+          { label: 'Show More', value: 'show' },
+        ],
+        validation: {},
+        depends_on: {
+          conditional_trigger: 1,
+        },
+      },
+      value: 'noshow',
+    },
+    conditional_2: {
+      metadata: {
+        label: 'Conditional Field 2',
+        field_type: 'text',
+        description: 'This is conditional on the top-level select',
+        validation: {},
+        depends_on: {
+          conditional_trigger: 2,
+        },
+      },
+      value: 'Conditional based on 2',
+    },
+  },
+  field_order: [
+    'unconditional',
+    'conditional_trigger',
+    'conditional_1',
+    'conditional_2',
+    'conditional_sub',
+  ],
+};
+
+export const realWorldSchema: FormSchema = {
+  fields: {
+    type: {
+      metadata: {
+        label: 'Connection type',
+        description: 'Type of connection.',
+        field_type: 'hidden',
+        encrypt: false,
+        validation: {
+          required: false,
+        },
+      },
+      value: 'spark',
+    },
+    method: {
+      metadata: {
+        label: 'Method',
+        description: 'Method of spark connection.',
+        field_type: 'select',
+        options: [
+          { label: 'HTTP', value: 'http' },
+          { label: 'Thrift', value: 'thirft' },
+        ],
+        encrypt: false,
+        validation: {
+          required: false,
+        },
+      },
+      value: 'http',
+    },
+    host_type: {
+      metadata: {
+        label: 'Databricks Host Type',
+        description: 'Who hosts your databricks cluster?',
+        field_type: 'select',
+        options: [
+          { label: 'Amazon', value: 'amazon' },
+          { label: 'Azure', value: 'azure' },
+        ],
+        depends_on: {
+          method: 'http',
+        },
+        encrypt: false,
+      },
+      value: 'amazon',
+    },
+    host: {
+      metadata: {
+        label: 'Hostname',
+        description: 'Host name of connection.',
+        field_type: 'text',
+        encrypt: false,
+        validation: {
+          required: false,
+        },
+      },
+      value: '',
+    },
+    port: {
+      metadata: {
+        label: 'Port',
+        description: 'Port number of host.',
+        field_type: 'number',
+        encrypt: false,
+        validation: {},
+      },
+      value: 443,
+    },
+    cluster: {
+      metadata: {
+        label: 'Cluster',
+        description: 'Cluster name',
+        field_type: 'text',
+        encrypt: false,
+        validation: {
+          required: false,
+        },
+      },
+      value: '',
+    },
+    connect_timeout: {
+      metadata: {
+        label: 'Connection Timeout',
+        description: 'Connection timeout in seconds',
+        field_type: 'number',
+        encrypt: false,
+        validation: {},
+      },
+      value: 10,
+    },
+    connect_retries: {
+      metadata: {
+        label: 'Connection Retries',
+        description: 'Connection retries in integer',
+        field_type: 'number',
+        encrypt: false,
+        validation: {},
+      },
+      value: 0,
+    },
+    organization: {
+      metadata: {
+        label: 'Organization',
+        description: 'Organization id',
+        field_type: 'text',
+        encrypt: false,
+        validation: {
+          required: false,
+        },
+        depends_on: {
+          method: 'http',
+          host_type: 'azure',
+        },
+      },
+      value: '',
+    },
+  },
+  field_order: [
+    'type',
+    'method',
+    'host_type',
+    'host',
+    'port',
+    'organization',
+    'cluster',
+    'user',
+    'connect_timeout',
+    'connect_retries',
+  ],
+};
+
+export const externalConditionalSchema: FormSchema = {
+  fields: {
+    unconditional: {
+      metadata: {
+        label: 'Unconditional Field',
+        field_type: 'text',
+        description: 'Never gonna let you go',
+        validation: {},
+        depends_on: {},
+      },
+      value: `I'm here to stay.`,
+    },
+    conditional: {
+      metadata: {
+        label: 'External Conditional',
+        field_type: 'text',
+        description: 'I only show based on external state',
+        validation: {},
+        depends_on: { showMore: true },
+      },
+      value: `I'm conditionally here!`,
+    },
+  },
+  field_order: ['unconditional', 'conditional'],
+};

--- a/components/Forms/SchemaForm/types.ts
+++ b/components/Forms/SchemaForm/types.ts
@@ -1,0 +1,29 @@
+import { SelectOption } from '../Select';
+
+export interface SchemaValidation {
+  required?: boolean;
+  minLength?: number;
+  maxLength?: number;
+  min?: number;
+  max?: number;
+  pattern?: 'email' | 'hostname' | 'fqdn';
+}
+
+export interface SchemaField {
+  metadata: {
+    id?: string;
+    field_type: 'text' | 'number' | 'select' | 'hidden';
+    label: string;
+    description: string;
+    encrypt?: boolean;
+    options?: SelectOption[];
+    validation?: SchemaValidation;
+    depends_on?: Record<string, string | number | boolean>;
+  };
+  value: string | number | SelectOption;
+}
+
+export interface FormSchema {
+  fields: Record<string, SchemaField>;
+  field_order: string[];
+}

--- a/components/Forms/Select/Select.tsx
+++ b/components/Forms/Select/Select.tsx
@@ -29,7 +29,7 @@ export interface SelectProps extends ReactSelectProps {
 const Option: FC = (props: any) => (
   <components.Option {...props}>
     <div className="fui-select__option_value">
-      <Icon icon={faCheck} />
+      <Icon icon={faCheck} className="tw-inline" />
       {props.data.label}
     </div>
     {props.data.meta && (

--- a/components/Forms/index.ts
+++ b/components/Forms/index.ts
@@ -1,2 +1,4 @@
 export * from './Field';
+export * from './Input';
+export * from './SchemaForm';
 export * from './Select';

--- a/package-lock.json
+++ b/package-lock.json
@@ -15099,6 +15099,11 @@
         "shallowequal": "^1.1.0"
       }
     },
+    "react-hook-form": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.11.0.tgz",
+      "integrity": "sha512-YoiNCKSfrLv0CCK9fiVorNt1YM5xOV4Fo+O3e3CphS6N4xrXah3rJo1YIA34qSbIJwXgcsS2WOIb2K/Wb6e56A=="
+    },
     "react-hotkeys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "react-select": "^3.1.0",
+    "react-hook-form": "^6.11.0",
     "uuid": "^8.3.0"
   },
   "prettier": {


### PR DESCRIPTION
- Adds `<FormSchema />` to take JSON and turn it into a (partial) form.
  - `<FormSchema />` is meant to be used inside of an implemented react-hook-form.. form, it doesn't provide the form wrapper for you, but it interacts directly with existing properties of a react-hook-form.
  - Provides support for `Input` and `Select` form elements
  - Provides support for validation
  - Provides support for conditional field rendering within generated form.
- Adds `useErrorMessages` hook for memoizing and providing simple error messages to `<FormSchema />`
- Adds tests, docs, examples

Preview:
https://deploy-preview-21--laughing-shockley-2b3f4c.netlify.app/?path=/docs/components-forms-schemaform--basic