### PR TITLE
Update styles for Inputs and Fields

### DIFF
--- a/components/Forms/Field/Field.tsx
+++ b/components/Forms/Field/Field.tsx
@@ -52,7 +52,7 @@ export const Field: FC<FieldProps> = ({
       'fui-field-row--is-invalid': error,
     }
   );
-  const hasHelpText = isEdit && helpText;
+
   const hasInput = isEdit && !!input;
   const hasChildren = isEdit && !input && !!children;
   const inputProps: FieldInputProps = {
@@ -68,8 +68,8 @@ export const Field: FC<FieldProps> = ({
       <div className="fui-field-row__value">
         {hasInput && input && input(inputProps)}
         {!hasInput && hasChildren && children && children(inputProps)}
-        {hasHelpText && (
-          <p className="tw-text-xs tw-text-gray-600 tw-italic tw-mt-1 tw-mb-1">
+        {isEdit && (
+          <p className="tw-text-xs tw-text-gray-600 tw-italic tw-mt-1 tw-mb-1 tw-h-6">
             {helpText}
           </p>
         )}

--- a/components/Forms/Field/field.css
+++ b/components/Forms/Field/field.css
@@ -20,6 +20,7 @@
       tw-duration-200
       tw-ease-out
       tw-w-full
+      tw-h-10
       tw-bg-gray-200 
       tw-shadow-none 
       tw-block 

--- a/components/Forms/Select/Select.tsx
+++ b/components/Forms/Select/Select.tsx
@@ -29,7 +29,7 @@ export interface SelectProps extends ReactSelectProps {
 const Option: FC = (props: any) => (
   <components.Option {...props}>
     <div className="fui-select__option_value">
-      <Icon icon={faCheck} />
+      <Icon icon={faCheck} className="tw-inline" />
       {props.data.label}
     </div>
     {props.data.meta && (


### PR DESCRIPTION
- Updates field styles to always include space for help text for evenly spaced form fields
- Updates Input to have a height
  - This height looks huge in the docs, it's significantly scaled down in dbt-cloud because we have a much smaller base font size.

Note: We should probably scale down the base font in the docs until we increase the base font in cloud.