### PR TITLE
Remove tailwind animations for now, so as not to conflict with dbt styleguide animations.

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -41,4 +41,8 @@ module.exports = {
     removeDeprecatedGapUtilities: true,
     purgeLayersByDefault: true,
   },
+  corePlugins: {
+    // https://github.com/fishtown-analytics/dbt-cloud/issues/1948
+    animation: false,
+  }
 };


### PR DESCRIPTION
Tailwind's animations caused some animations in dbt Cloud to break. Removing them fixes the existing animations.

In time I imagine we will re-enable these tailwind animations, and disable the dbt Cloud animations. But for now this gets things back into a good state.

Functionally tested this by installing via `npm link`, then reloading dbt Cloud UI.