### PR TITLE
Add support for sectionHeader field in Select dropdown

### DIFF
--- a/components/Forms/Select/Select.test.tsx
+++ b/components/Forms/Select/Select.test.tsx
@@ -70,3 +70,19 @@ test('a grouping meta label is displayed if provided', async () => {
   expect(queryByText('Group Test')).toBeDefined();
   expect(queryByText('Test Meta Label')).toBeDefined();
 });
+
+test('section names are displayed if provided', async () => {
+  const groupedOptions: SelectOption[] = [{ label: 'Group Test', sectionHeader: 'First Header', options }, { label: 'Group Test 2', sectionHeader: 'Second Header', options }];
+  const { getByText, queryByText } = render(
+    <Select
+      options={groupedOptions}
+      onChange={voidChange}
+      groupingMetaLabel="Test Meta Label"
+    />
+  );
+  await selectEvent.openMenu(getByText('Select...'));
+  expect(queryByText('Group Test')).toBeDefined();
+  expect(queryByText('First Header')).toBeDefined();
+  expect(queryByText('Group Test 2')).toBeDefined();
+  expect(queryByText('Second Header')).toBeDefined();
+});

--- a/components/Forms/Select/Select.tsx
+++ b/components/Forms/Select/Select.tsx
@@ -6,14 +6,9 @@ import cx from 'classnames';
 
 import { Icon } from '../../Icon';
 
-enum StyleMode {
-  DEFAULT = 0,
-  COLUMNS
-}
-
 export interface SelectOption {
   label: string;
-  sectionName?: string;
+  sectionHeader?: string;
   value?: any;
   meta?: string;
   options?: SelectOption[];
@@ -30,15 +25,13 @@ export interface SelectProps extends ReactSelectProps<SelectOption> {
   value?: SelectOption | null;
   portal?: boolean;
   onChange?(value: SelectOption): void;
-  styleMode?: StyleMode;
 }
 
 const Option: FC = (props: any) => {
-  const shouldUseCheckMark = props.styleMode !== StyleMode.COLUMNS;
-  return(
+  return (
   <components.Option {...props}>
     <div className="fui-select__option_value">
-      {shouldUseCheckMark && <Icon icon={faCheck} className="tw-inline" />}
+      <Icon icon={faCheck} className="tw-inline" />
       {props.data.label}
     </div>
     {props.data.meta && (
@@ -48,13 +41,12 @@ const Option: FC = (props: any) => {
 )};
 
 export const Select: FC<SelectProps> = (props: SelectProps): React.ReactElement => {
-  const { groupingMetaLabel, value, styleMode } = props;
+  const { groupingMetaLabel, value } = props;
   const [localValue, setValue] = useState(value);
   const classNames = cx(
     'fui-select-container',
     props.className,
-    { 'fui-select--is-errored': !!props.error, },
-    { 'fui-select--columns' : styleMode == StyleMode.DEFAULT, });
+    { 'fui-select--is-errored': !!props.error, });
   const innerSelectProps = { 'aria-labelledby': props.id, ...props };
   useEffect(() => {
     setValue(value);
@@ -73,7 +65,7 @@ export const Select: FC<SelectProps> = (props: SelectProps): React.ReactElement 
   const formatGroupLabel = useCallback(
     (data): React.ReactNode => (
       <>
-      {data.sectionName && <div className="fui-select__sectionname">{data.sectionName}</div>}
+      {data.sectionHeader && <div className="fui-select__section-header">{data.sectionHeader}</div>}
       <div className={"fui-select__grouplabel"}>
         <div className="fui-select__grouplabel_title">{data.label}</div>
         <div className="fui-select__grouplabel_meta">
@@ -106,7 +98,4 @@ Select.defaultProps = {
   options: [],
   value: null,
   portal: false,
-  styleMode: StyleMode.DEFAULT,
 };
-
-Select.StyleMode = StyleMode;

--- a/components/Forms/Select/Select.tsx
+++ b/components/Forms/Select/Select.tsx
@@ -42,10 +42,9 @@ const Option: FC = (props: any) => (
 export const Select: FC<SelectProps> = (props: SelectProps): React.ReactElement => {
   const { groupingMetaLabel, value } = props;
   const [localValue, setValue] = useState(value);
-  const classNames = cx(
-    'fui-select-container',
-    props.className,
-    { 'fui-select--is-errored': !!props.error, });
+  const classNames = cx('fui-select-container', props.className, {
+    'fui-select--is-errored': !!props.error,
+  });
   const innerSelectProps = { 'aria-labelledby': props.id, ...props };
   useEffect(() => {
     setValue(value);

--- a/components/Forms/Select/Select.tsx
+++ b/components/Forms/Select/Select.tsx
@@ -8,7 +8,7 @@ import { Icon } from '../../Icon';
 
 export interface SelectOption {
   label: string;
-  value?: string;
+  value?: any;
   meta?: string;
   options?: SelectOption[];
 }

--- a/components/Forms/Select/Select.tsx
+++ b/components/Forms/Select/Select.tsx
@@ -27,8 +27,7 @@ export interface SelectProps extends ReactSelectProps<SelectOption> {
   onChange?(value: SelectOption): void;
 }
 
-const Option: FC = (props: any) => {
-  return (
+const Option: FC = (props: any) => (
   <components.Option {...props}>
     <div className="fui-select__option_value">
       <Icon icon={faCheck} className="tw-inline" />
@@ -38,7 +37,7 @@ const Option: FC = (props: any) => {
       <div className="fui-select__option_meta">{props.data.meta}</div>
     )}
   </components.Option>
-)};
+);
 
 export const Select: FC<SelectProps> = (props: SelectProps): React.ReactElement => {
   const { groupingMetaLabel, value } = props;

--- a/components/Forms/Select/Select.tsx
+++ b/components/Forms/Select/Select.tsx
@@ -6,8 +6,14 @@ import cx from 'classnames';
 
 import { Icon } from '../../Icon';
 
+enum StyleMode {
+  DEFAULT = 0,
+  COLUMNS
+}
+
 export interface SelectOption {
   label: string;
+  sectionName?: string;
   value?: any;
   meta?: string;
   options?: SelectOption[];
@@ -24,26 +30,31 @@ export interface SelectProps extends ReactSelectProps<SelectOption> {
   value?: SelectOption | null;
   portal?: boolean;
   onChange?(value: SelectOption): void;
+  styleMode?: StyleMode;
 }
 
-const Option: FC = (props: any) => (
+const Option: FC = (props: any) => {
+  const shouldUseCheckMark = props.styleMode !== StyleMode.COLUMNS;
+  return(
   <components.Option {...props}>
     <div className="fui-select__option_value">
-      <Icon icon={faCheck} className="tw-inline" />
+      {shouldUseCheckMark && <Icon icon={faCheck} className="tw-inline" />}
       {props.data.label}
     </div>
     {props.data.meta && (
       <div className="fui-select__option_meta">{props.data.meta}</div>
     )}
   </components.Option>
-);
+)};
 
 export const Select: FC<SelectProps> = (props: SelectProps): React.ReactElement => {
-  const { groupingMetaLabel, value } = props;
+  const { groupingMetaLabel, value, styleMode } = props;
   const [localValue, setValue] = useState(value);
-  const classNames = cx('fui-select-container', props.className, {
-    'fui-select--is-errored': !!props.error,
-  });
+  const classNames = cx(
+    'fui-select-container',
+    props.className,
+    { 'fui-select--is-errored': !!props.error, },
+    { 'fui-select--columns' : styleMode == StyleMode.DEFAULT, });
   const innerSelectProps = { 'aria-labelledby': props.id, ...props };
   useEffect(() => {
     setValue(value);
@@ -61,12 +72,15 @@ export const Select: FC<SelectProps> = (props: SelectProps): React.ReactElement 
   // Used if options are an array of groupings
   const formatGroupLabel = useCallback(
     (data): React.ReactNode => (
-      <div className="fui-select__grouplabel">
+      <>
+      {data.sectionName && <div className="fui-select__sectionname">{data.sectionName}</div>}
+      <div className={"fui-select__grouplabel"}>
         <div className="fui-select__grouplabel_title">{data.label}</div>
         <div className="fui-select__grouplabel_meta">
           {groupingMetaLabel || (data.options && data.options.length)}
         </div>
       </div>
+      </>
     ),
     [groupingMetaLabel]
   );
@@ -92,4 +106,7 @@ Select.defaultProps = {
   options: [],
   value: null,
   portal: false,
+  styleMode: StyleMode.DEFAULT,
 };
+
+Select.StyleMode = StyleMode;

--- a/components/Forms/Select/select.css
+++ b/components/Forms/Select/select.css
@@ -47,13 +47,9 @@
   @apply tw-flex tw-align-middle tw-justify-between;
 }
 
-.fui-select-container.fui-select--columns .fui-select__grouplabel {
-  @apply tw-flex tw-align-middle tw-justify-between;
-}
-
-.fui-select-container .fui-select__grouplabel_sectionheader {
-  color: red;
-  font-size: 20px;
+.fui-select-container .fui-select__section-header {
+  font-size: 15px;
+  text-transform: none;
 }
 
 .fui-select__indicator-separator {

--- a/components/Forms/Select/select.css
+++ b/components/Forms/Select/select.css
@@ -48,7 +48,7 @@
 }
 
 .fui-select-container .fui-select__section-header {
-  font-size: 15px;
+  @apply tw-text-lg;
   text-transform: none;
 }
 

--- a/components/Forms/Select/select.css
+++ b/components/Forms/Select/select.css
@@ -47,6 +47,15 @@
   @apply tw-flex tw-align-middle tw-justify-between;
 }
 
+.fui-select-container.fui-select--columns .fui-select__grouplabel {
+  @apply tw-flex tw-align-middle tw-justify-between;
+}
+
+.fui-select-container .fui-select__grouplabel_sectionheader {
+  color: red;
+  font-size: 20px;
+}
+
 .fui-select__indicator-separator {
   @apply tw-hidden;
 }


### PR DESCRIPTION
This PR is needed for [dbt-cloud/PR#2516](https://github.com/fishtown-analytics/dbt-cloud/pull/2516).

Add an optional header string for each section in a Select dropdown.

![image](https://user-images.githubusercontent.com/1190438/112346333-3d875c00-8c9c-11eb-9da3-35655691c651.png)